### PR TITLE
feat: add new no-i18next-import rule

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ module.exports = {
   rules: {
     '@sanity/i18n/no-attribute-string-literals': 'error',
     '@sanity/i18n/no-attribute-template-literals': 'error',
+    '@sanity/i18n/no-i18next-import': 'error',
   },
 };
 ```
@@ -112,6 +113,29 @@ Examples of **correct** code for this rule:
 <MyComponent booleanAttr numberAttr={5}>
 ```
 
+### `no-i18next-import`
+
+This rule finds imports of the `i18next` and `react-i18next` package. While these packages are (currently) used as dependencies of `sanity`, this is considered an implementation detail and should not be relied upon. Instead, you should import any i18n utility/helper from the `sanity` module directly.
+
+Examples of **incorrect** code for this rule:
+
+```js
+// 🛑 importing from `react-i18next``
+import { useTranslation } from 'react-i18next';
+```
+
+```js
+// 🛑 requiring from `react-i18next``
+const { Trans } = require('react-i18next');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// ✅ requiring from `sanity`
+const { Translate } = require('sanity');
+```
+
 ## Usage
 
 In your ESLint config, add `"@sanity/i18n"` to the list of plugins and enable the rules:
@@ -149,6 +173,7 @@ module.exports = {
         mode: 'extend',
       },
     ],
+    '@sanity/i18n/no-i18next-import': 'error',
   },
 };
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@typescript-eslint/typescript-estree": "^6.13.1",
         "eslint": "^8.54.0",
         "jest": "^29.7.0",
+        "prettier": "^3.2.4",
         "rollup": "^4.6.1",
         "typescript": "^5.3.2"
       }
@@ -12677,6 +12678,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@rollup/plugin-replace": "^5.0.5",
         "@sanity/semantic-release-preset": "^4.1.6",
         "@types/eslint": "^8.44.8",
+        "@types/node": "^18.0.0",
         "@typescript-eslint/parser": "^6.13.1",
         "@typescript-eslint/rule-tester": "^6.13.1",
         "@typescript-eslint/typescript-estree": "^6.13.1",
@@ -3903,9 +3904,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
-      "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@sanity/semantic-release-preset": "^4.1.6",
     "@types/eslint": "^8.44.8",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/parser": "^6.13.1",
     "@typescript-eslint/rule-tester": "^6.13.1",
     "@typescript-eslint/typescript-estree": "^6.13.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest",
     "build": "tsc && rollup -c",
+    "prettify": "prettier -w .",
     "prepare": "npm run build"
   },
   "repository": {
@@ -41,6 +42,7 @@
     "@typescript-eslint/typescript-estree": "^6.13.1",
     "eslint": "^8.54.0",
     "jest": "^29.7.0",
+    "prettier": "^3.2.4",
     "rollup": "^4.6.1",
     "typescript": "^5.3.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { ESLint } from 'eslint';
 
 import { noAttributeStringLiterals } from './no-attribute-string-literals';
 import { noAttributeTemplateLiterals } from './no-attribute-template-literals';
+import { noI18NextImport } from './no-i18next-import';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -11,6 +12,7 @@ const plugin: ESLint.Plugin = {
   rules: {
     'no-attribute-string-literals': noAttributeStringLiterals,
     'no-attribute-template-literals': noAttributeTemplateLiterals,
+    'no-i18next-import': noI18NextImport,
   },
 };
 

--- a/src/no-i18next-import.test.ts
+++ b/src/no-i18next-import.test.ts
@@ -1,0 +1,96 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noI18NextImport } from './no-i18next-import';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: { jsx: true },
+  },
+});
+
+ruleTester.run(
+  'no-i18next-import',
+  // @ts-expect-error
+  noI18NextImport,
+  {
+    valid: [
+      {
+        code: 'import {useTranslation} from "sanity"',
+      },
+      {
+        code: 'import {Translate} from "sanity"',
+      },
+      {
+        code: 'const {useTranslation} = require("sanity")',
+      },
+      {
+        code: 'const {Translate} = require("sanity")',
+      },
+    ],
+    invalid: [
+      // Straight imports
+      {
+        code: 'import i18next from "i18next"',
+        errors: [
+          `Importing from 'i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: 'import i18next from "i18next"',
+      },
+      {
+        code: 'import reactI18next from "react-i18next"',
+        errors: [
+          `Importing from 'react-i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: 'import reactI18next from "react-i18next"',
+      },
+
+      // Straight requires
+      {
+        code: 'const i18next = require("i18next")',
+        errors: [
+          `Importing from 'i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: 'const i18next = require("i18next")',
+      },
+      {
+        code: 'const reactI18next = require("react-i18next")',
+        errors: [
+          `Importing from 'react-i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: 'const reactI18next = require("react-i18next")',
+      },
+
+      // useTranslation imports
+      {
+        code: 'import {useTranslation} from "react-i18next"',
+        errors: [
+          `Importing from 'react-i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: 'import {useTranslation} from "sanity"',
+      },
+      {
+        code: `import {useTranslation} from 'react-i18next'`,
+        errors: [
+          `Importing from 'react-i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: `import {useTranslation} from 'sanity'`,
+      },
+
+      // useTranslation requires
+      {
+        code: `const {useTranslation} = require("react-i18next")`,
+        errors: [
+          `Importing from 'react-i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: `const {useTranslation} = require("sanity")`,
+      },
+      {
+        code: `const {useTranslation} = require('react-i18next')`,
+        errors: [
+          `Importing from 'react-i18next' is not allowed. Import from 'sanity' instead.`,
+        ],
+        output: `const {useTranslation} = require('sanity')`,
+      },
+    ],
+  },
+);

--- a/src/no-i18next-import.ts
+++ b/src/no-i18next-import.ts
@@ -1,0 +1,119 @@
+import type ESLint from 'eslint';
+
+const disallowedImports = ['i18next', 'react-i18next'];
+
+export const noI18NextImport: ESLint.Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        // Is literal string import?
+        if (typeof node.source.value !== 'string') {
+          return;
+        }
+
+        // Is disallowed import?
+        if (!disallowedImports.includes(node.source.value)) {
+          return;
+        }
+
+        // Is this fixable? (only if importing useTranslation)
+        let fix: ESLint.Rule.ReportFixer | undefined;
+        if (
+          node.specifiers.length === 1 &&
+          node.specifiers.some(
+            (specifier) =>
+              specifier.type === 'ImportSpecifier' &&
+              specifier.imported.name === 'useTranslation',
+          )
+        ) {
+          // Are we importing with single or double quotes (try to maintain code style)
+          const quote =
+            node.source.raw && node.source.raw.trim()[0] === `'` ? `'` : `"`;
+          fix = (fixer) =>
+            node.source.range
+              ? fixer.replaceTextRange(
+                  node.source.range,
+                  `${quote}sanity${quote}`,
+                )
+              : fixer.replaceText(
+                  node,
+                  `import {useTranslation} from ${quote}sanity${quote}`,
+                );
+        }
+
+        context.report({
+          node,
+          message: `Importing from '${node.source.value}' is not allowed. Import from 'sanity' instead.`,
+          fix,
+        });
+      },
+      CallExpression(node) {
+        node.parent.type;
+        // Is require call?
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'require'
+        ) {
+          return;
+        }
+
+        // Require has single literal string argument?
+        if (
+          node.arguments.length !== 1 ||
+          node.arguments[0].type !== 'Literal' ||
+          typeof node.arguments[0].value !== 'string'
+        ) {
+          return;
+        }
+
+        // Is disallowed import?
+        if (!disallowedImports.includes(node.arguments[0].value)) {
+          return;
+        }
+
+        // Is this fixable? (only if importing useTranslation)
+        let fix: ESLint.Rule.ReportFixer | undefined;
+        if (isUseTranslationDecl(node)) {
+          // Are we importing with single or double quotes (try to maintain code style)
+          const raw = node.arguments[0].raw;
+          const quote = raw && raw[0] === `'` ? `'` : `"`;
+          fix = (fixer) =>
+            node.arguments[0].range
+              ? fixer.replaceTextRange(
+                  node.arguments[0].range,
+                  `${quote}sanity${quote}`,
+                )
+              : fixer.replaceText(
+                  node,
+                  `const {useTranslation} = require(${quote}sanity${quote})`,
+                );
+        }
+
+        context.report({
+          node,
+          message: `Importing from '${node.arguments[0].value}' is not allowed. Import from 'sanity' instead.`,
+          fix,
+        });
+      },
+    };
+  },
+};
+
+function isUseTranslationDecl(call: ESLint.Rule.NodeParentExtension) {
+  const parent = call.parent;
+  return (
+    parent.type === 'VariableDeclarator' &&
+    parent.id.type === 'ObjectPattern' &&
+    parent.id.properties.length === 1 &&
+    parent.id.properties.some(
+      (prop) =>
+        prop.type === 'Property' &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'useTranslation',
+    )
+  );
+}


### PR DESCRIPTION
This rule finds imports of the `i18next` and `react-i18next` package.

While these packages are (currently) used as dependencies of `sanity`, this is considered an implementation detail and should not be relied upon. Instead, you should import any i18n utility/helper from the `sanity` module directly.

Also added `prettier` and `@types/node` dependencies (for autoformatting and to fix a type issue on build because of `process.env` usage)