### PR TITLE
refactor: fix semantic-release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,21 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
+      contents: read
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        - uses: actions/create-github-app-token@v2
+          id: app-token
+          with:
+            app-id: ${{ secrets.ECOSPARK_APP_ID }}
+            private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -32,6 +38,6 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- Update semantic-release workflow to use `actions/create-github-app-token@v2` instead of `GITHUB_TOKEN`
- This fixes issues with GitHub rulesets that require pull requests
- Matches the pattern from https://github.com/sanity-io/tracing/pull/50

## Changes
- Add `actions/create-github-app-token@v2` step
- Update `actions/checkout` to use the generated token
- Update permissions to only `contents: read` and `id-token: write`
- Use `${{ steps.app-token.outputs.token }}` instead of `${{ secrets.GITHUB_TOKEN }}`

## Reference
See: https://github.com/sanity-io/sanity-plugin-mux-input/commit/8d9b59216b30f3e3662eae5d6e02754ecec6af69

🤖 Generated with [Claude Code](https://claude.com/claude-code)