### PR TITLE
fix: correct yaml structure in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
       contents: read
       id-token: write # to enable use of OIDC for npm provenance
     steps:
-      - name: Checkout
-        - uses: actions/create-github-app-token@v2
-          id: app-token
-          with:
-            app-id: ${{ secrets.ECOSPARK_APP_ID }}
-            private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
 
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- Fix invalid YAML in release workflow where `create-github-app-token` step was incorrectly nested inside the Checkout step
- Follows up on #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)